### PR TITLE
Modify row index string in place

### DIFF
--- a/lib/fixture_builder/builder.rb
+++ b/lib/fixture_builder/builder.rb
@@ -137,7 +137,7 @@ module FixtureBuilder
           end
           next files if rows.empty?
 
-          row_index = '000'
+          row_index = +'000'
           fixture_data = rows.inject({}) do |hash, record|
             hash.merge(record_name(record, table_name, row_index) => record)
           end

--- a/lib/fixture_builder/namer.rb
+++ b/lib/fixture_builder/namer.rb
@@ -47,9 +47,13 @@ module FixtureBuilder
     end
 
     def record_name(record_hash, table_name, row_index)
+      if row_index.frozen?
+        raise('The row_index string argument must not be frozen.')
+      end
+
       key = [table_name, record_hash['id'].to_i]
       name = if (name_proc = @model_name_procs[table_name])
-               name_proc.call(record_hash, row_index.succ)
+               name_proc.call(record_hash, row_index.succ!)
              elsif (custom = @custom_names[key])
                custom
              else
@@ -73,7 +77,7 @@ module FixtureBuilder
         end
         return count.zero? ? inferred_name : "#{inferred_name}_#{count}"
       end
-      [table_name, row_index.succ].join('_')
+      [table_name, row_index.succ!].join('_')
     end
   end
 end

--- a/test/fixture_builder_test.rb
+++ b/test/fixture_builder_test.rb
@@ -23,7 +23,7 @@ class FixtureBuilderTest < Test::Unit::TestCase
         [record_hash['email'].split('@').first, index].join('_')
       end
     end
-    assert_equal 'bob_001', FixtureBuilder.configuration.send(:record_name, hash, Model.table_name, '000')
+    assert_equal 'bob_001', FixtureBuilder.configuration.send(:record_name, hash, Model.table_name, +'000')
   end
 
   def test_ivar_naming

--- a/test/namer_test.rb
+++ b/test/namer_test.rb
@@ -40,7 +40,7 @@ class NamerTest < Test::Unit::TestCase
       [record_hash['email'].split('@').first, index].join('_')
     end
 
-    assert_equal 'bob_001', @namer.record_name(hash, Model.table_name, '000')
+    assert_equal 'bob_001', @namer.record_name(hash, Model.table_name, +'000')
   end
 
   def test_record_name_without_name_with_or_custom_name
@@ -48,7 +48,7 @@ class NamerTest < Test::Unit::TestCase
       'id' => 1,
       'email' => 'bob@example.com'
     }
-    assert_equal 'models_001', @namer.record_name(hash, Model.table_name, '000')
+    assert_equal 'models_001', @namer.record_name(hash, Model.table_name, +'000')
   end
 
   def test_record_name_with_inferred_record_name
@@ -57,7 +57,7 @@ class NamerTest < Test::Unit::TestCase
       'title' => 'foo',
       'email' => 'bob@example.com'
     }
-    assert_equal 'foo', @namer.record_name(hash, Model.table_name, '000')
+    assert_equal 'foo', @namer.record_name(hash, Model.table_name, +'000')
   end
 
   def test_name_not_unique_across_tables
@@ -69,9 +69,9 @@ class NamerTest < Test::Unit::TestCase
       'id' => 2,
       'title' => 'foo'
     }
-    assert_equal 'foo', @namer.record_name(hash, Model.table_name, '000')
-    assert_equal 'foo', @namer.record_name(hash, AnotherModel.table_name, '000')
-    assert_equal 'foo_1', @namer.record_name(hash_with_same_title, Model.table_name, '000')
+    assert_equal 'foo', @namer.record_name(hash, Model.table_name, +'000')
+    assert_equal 'foo', @namer.record_name(hash, AnotherModel.table_name, +'000')
+    assert_equal 'foo_1', @namer.record_name(hash_with_same_title, Model.table_name, +'000')
   end
 
   def test_populate_custom_names_for_rails_30_and_earlier
@@ -79,6 +79,6 @@ class NamerTest < Test::Unit::TestCase
       'foo' => MockFixture
     }
     @namer.populate_custom_names(mock_fixtures)
-    assert_equal 'foo', @namer.record_name(MockFixture, Model.table_name, '1')
+    assert_equal 'foo', @namer.record_name(MockFixture, Model.table_name, +'1')
   end
 end


### PR DESCRIPTION
Modifying the string in place seems necessary in order for things to work. (Tests pass with a frozen string, but issues occur when trying to use the gem in an application's test suite.)